### PR TITLE
overloaded modulo operator on lazyT for printf-style formatting

### DIFF
--- a/pluralize/__init__.py
+++ b/pluralize/__init__.py
@@ -36,6 +36,10 @@ class lazyT(object):
         """str(T('dog')) -> 'cane'"""
         return self.xml()
 
+    def __mod__(self, obj):
+        """T('route %d') % 66 -> 'route 66'"""
+        return self.xml() % obj
+
     def xml(self):
         """same as str but for interoperability with yatl helpers"""
         return self.translator(self.text, **self.kwargs)


### PR DESCRIPTION
solve
**TypeError: unsupported operand type(s) for %: 'lazyT' and 'dict'**
when using some pydal.validators in py4web for example:
``IS_FLOAT_IN_RANGE(1, None, error_message=T("Raggio d'azione invalido (< %(min).1f km)"))(0)``

