### PR TITLE
enforce utf-8 encoding when reading language.json files

### DIFF
--- a/pluralize/__init__.py
+++ b/pluralize/__init__.py
@@ -68,7 +68,7 @@ class Translator(object):
         self.languages = {}
         for filename in os.listdir(folder):
             if re_language.match(filename):
-                with open(os.path.join(folder, filename), "r") as fp:
+                with open(os.path.join(folder, filename), "r", encoding="utf-8") as fp:
                     self.languages[filename[:-5].lower()] = json.load(fp)
 
     def save(self, folder=None):


### PR DESCRIPTION
make sure that the load method of the Translator class reads language.json files in utf-8 encoding